### PR TITLE
Align terminology with Developer Portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The provided options object must contain an `auth` object with the following spe
 |--------|-----|--------|-----------|
 |`type`|`'jwt'` or `'bearer'`|Yes|The authentication type. This is either a JWT or a Bearer Token.|
 |`token`|`String`|If `type` is `'bearer'`.|The token associared with the bearer token credentials.|
-|`email`|`String`|If `type` is `'jwt'`.|The email associated with the JWT credentials.|
+|`issuer`|`String`|If `type` is `'jwt'`.|The issuer associated with the JWT credentials.|
 |`secret`|`String`|If `type` is `'jwt'`.|The secret associated with the JWT credentials.|
 
 ## Examples
@@ -64,7 +64,7 @@ const instance = createInstance({
   'applicationName': 'My Application v1.0.1',
   'auth': {
     'type': 'bearer',
-    'email': 'my_email',
+    'issuer': 'my_issuer',
     'secret': 'my_secret',
   },
 });

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,11 +4,11 @@ const { bearerBuilder, jwtBuilder } = require('./auth/builders');
 /**
  * Creates an API instance with JWT authorization.
  *
- * @param {string} email The email for the JWT.
+ * @param {string} issuer The issuer for the JWT.
  * @param {string} secret The secret for the JWT.
  */
-function jwt(email, secret) {
-  return createInstance(jwtBuilder(email, secret));
+function jwt(issuer, secret) {
+  return createInstance(jwtBuilder(issuer, secret));
 }
 
 /**

--- a/lib/auth/builders.js
+++ b/lib/auth/builders.js
@@ -4,17 +4,17 @@ const { URL, URLSearchParams } = require('url');
 /**
  * Builds JWT authorization.
  *
- * @param email The email to use.
+ * @param issuer The issuer to use.
  * @param secret The secret to use.
  * @returns {function(config: Object): string}
  */
-function jwtBuilder(email, secret) {
+function jwtBuilder(issuer, secret) {
   return (config) => {
     const url = new URL(config.url, config.baseURL);
     url.search = (new URLSearchParams(config.params)).toString();
     config.url = url.toString();
     config.params = {};
-    return `JWT ${signJWT(email, config.method, decodeURIComponent(url.pathname + url.search), secret)}`;
+    return `JWT ${signJWT(issuer, config.method, decodeURIComponent(url.pathname + url.search), secret)}`;
   };
 }
 

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -7,11 +7,11 @@ function getBuilder(auth) {
   }
 
   if (type === 'jwt') {
-    const { email, secret } = auth;
-    if (!email || !secret) {
-      throw new Error('JWT authentication requires an email and a secret.');
+    const { email, issuer, secret } = auth;
+    if (!(email || issuer) || !secret) {
+      throw new Error('JWT authentication requires an issuer and a secret.');
     }
-    return builders.jwtBuilder(email, secret);
+    return builders.jwtBuilder(issuer || email, secret);
   } else if (type === 'bearer') {
     const { token } = auth;
     if (!token) {

--- a/lib/auth/sign.js
+++ b/lib/auth/sign.js
@@ -4,20 +4,20 @@ const { toBase64URL, objectToBase64 } = require('../util');
 /**
  * Creates a JWT.
  *
- * @param {string} email The email to use.
+ * @param {string} issuer The issuer to use.
  * @param {string} method The HTTP method on the path.
  * @param {string} path The path. This should include the query parameters. Hash is not supported.
  * @param {string} key The private key.
  * @returns {string} A token to use in authorization.
  */
-function signJWT(email, method, path, key) {
+function signJWT(issuer, method, path, key) {
   const header = {
     'alg': 'HS256',
     'typ': 'JWT',
   };
   const payload = {
     'exp': Date.now() / 1000 | 0,
-    'iss': email,
+    'iss': issuer,
     'mth': method,
     'sub': path,
   };

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -15,7 +15,7 @@ const USER_AGENT = `Salling Group SDK v${pkg.version}`;
  * @param {Object} options Options for the instance.
  * @param {Object} options.auth Credentials for the instance.
  * @param {String} options.auth.type The type of authentication.
- * @param {String} [options.auth.email] The email used for JWT.
+ * @param {String} [options.auth.issuer] The issuer used for JWT.
  * @param {String} [options.auth.secret] The secret used for JWT.
  * @param {String} [options.auth.token] The token used for Bearer.
  * @param {String} [options.applicationName]


### PR DESCRIPTION
It's a bad idea to include user emails in JSON Web Tokens. The primary
concern is that our users will have their real emails exposed if any JWT
is ever inspected by anyone. There are a number of ways to avoid this,
and the easiest one is probably to just use opaque tokens instead of
emails.

Our developer portal will be issuing JWT credentials with opaque tokens,
so it makes little sense to have our SDK use terminology that matches
old and undesired behavior. Credentials issued with an email as issuer
should also make sense with this new terminology. "Issuer" could
describe an ID as well as an email, which should result in low friction
for "old" users reading the new documentation (when it's fully updated).

This commit is essentially a search-and-replace: "email" → "issuer"

It's not a breaking change as "email" still works. If both "email" and
"issuer" are present, "issuer" will be used. We'll just not mention the
support for "email" anywhere as it's considered deprecated.