### PR TITLE
Fix type in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you use a JWT, you can access the API like so:
 const instance = createInstance({
   'applicationName': 'My Application v1.0.1',
   'auth': {
-    'type': 'bearer',
+    'type': 'jwt',
     'issuer': 'my_issuer',
     'secret': 'my_secret',
   },


### PR DESCRIPTION
The documentation has a typo that could be confusing to its readers.